### PR TITLE
pyproject.toml: Include Missing Files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,11 @@ Issues = "https://github.com/aesc-silicon/gdsfill/issues"
 
 [project.scripts]
 gdsfill = "gdsfill.gdsfill:main"
+
+[tool.setuptools.package-data]
+gdsfill = [
+    "library/layers.yaml",
+    "configs/*.yaml",
+    "ihp-sg13g2/*yaml",
+    "ihp-sg13g2/*py",
+]


### PR DESCRIPTION
There are YAML config files and the entire ihp-sg13g2 directory missing in the packed package. Add those via the pyproject.toml file.