### PR TITLE
Release v0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "gdsfill"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gdsfill"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 authors = ["Daniel Schultz <dnltz@aesc-silicon.de>"]
 description = "Open-source tool for inserting dummy metal fill into semiconductor layouts."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gdsfill"
-version = "0.1.6"
+version = "0.1.7"
 description = "Open-source tool for inserting dummy metal fill into semiconductor layouts."
 authors = [
     { name = "Daniel Schultz", email = "dnltz@aesc-silicon.de" }


### PR DESCRIPTION
Mostly fixes for the Rust implementation.

Fill correctness:
- Replace per-tile Square fill with a chip-global lattice anchored at the chip origin (each cell owned by the tile containing its centre). Adjacent tiles share one lattice, so fills are automatically >= min_space apart with no edge inset -- the dead per-tile border is gone and density no longer depends on tile size. Drop the old binary-search path (fill_square_tile, generate_fill, iter_fill_positions, is_valid_placement, clip_to_tile).
- gather_keepout_halo reads keepout from the 3x3 tile neighbourhood, and fills from earlier passes are indexed globally and fed as keepout to later passes, so Track<->Square and fill-to-drawn spacing holds across seams.
- Guard Track tile seams in both X and Y: reserve min_space at the upper/right edge in both axes (was routing-direction only), fixing Metal2 M2Fil minimum-space DRC errors at seams (e.g. gap collapsing 0.48 -> 0.24 um).

Density / overfill:
- fill_square_global now respects the remaining density budget instead of tiling every empty lattice cell; candidates are thinned to (target - running) via a deterministic per-cell hash, fixing overshoot on Activ/Metal1/TopMetal and the Metal3/4/5 Square second pass while staying DRC-clean.
- Add an 800 um (pdk.tile_width_um) window density cap so density is enforced over the foundry window, not the 100 um fill tile; padframe metal can no longer let sparse tiles push a whole window over target.

PDK:
- Give Metal3/4/5 the full Track pass set (pass_fracs + free_heights) already used by Metal2, so routed cores get channel-filling stripes.
- Rename shared keepout module ihp_sg13g2 -> ihp_sg13 (used by both ihp-sg13g2 and ihp-sg13cmos5l).
- ihp-sg13cmos5l: reduce working tile size 400 -> 100 um to match ihp-sg13g2 and speed up the per-tile density merge.

GDS reading:
- Ignore $$-prefixed tool-artifact cells (e.g. KLayout's $$$CONTEXT_INFO$$$) as both reference sources and flatten roots, so stale placements (e.g. a duplicated un-rotated seal ring) no longer leak into flattened geometry.