### PR TITLE
Limit published crate to Rust sources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,13 @@ readme = "src/README.md"
 repository = "https://github.com/aesc-silicon/gdsfill"
 keywords = ["gds", "eda", "vlsi", "fill", "layout"]
 categories = ["command-line-utilities", "science"]
+include = [
+    "src/**/*.rs",
+    "src/configs/*.yaml",
+    "src/README.md",
+    "/COPYING",
+    "/LICENSE",
+]
 
 [profile.release]
 opt-level = 3        # maximum optimization


### PR DESCRIPTION
Add a Cargo include whitelist so cargo package/publish bundles only src/, the example configs, README, and license files -- not the Python gdsfill/ tree, build metadata, or venv directories.