### PR TITLE
Fix PIP Installation

### DIFF
--- a/gdsfill/gdsfill.py
+++ b/gdsfill/gdsfill.py
@@ -226,7 +226,8 @@ def arguments(args=None):
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("--process", default="ihp-sg13g2")
-    subparsers = parser.add_subparsers(help='subcommand help')
+    subparsers = parser.add_subparsers(dest='command', required=True,
+                                       help='subcommand help')
     parser_fill = subparsers.add_parser('fill', help='Fill chip with dummy metal')
     parser_fill.add_argument("input", type=is_valid_file)
     parser_fill.add_argument('--keep-data', action=argparse.BooleanOptionalAction)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ Issues = "https://github.com/aesc-silicon/gdsfill/issues"
 [project.scripts]
 gdsfill = "gdsfill.gdsfill:main"
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["gdsfill*"]
+
 [tool.setuptools.package-data]
 gdsfill = [
     "library/layers.yaml",


### PR DESCRIPTION
After the Rust implementation was introduced, the Python package was empty. Define the source path in pyproject.toml and fix one issue in with argparser.

Closes #37 