### PR TITLE
Release v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "gdsfill"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gdsfill"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 authors = ["Daniel Schultz <dnltz@aesc-silicon.de>"]
 description = "Open-source tool for inserting dummy metal fill into semiconductor layouts."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gdsfill"
-version = "0.1.7"
+version = "0.1.8"
 description = "Open-source tool for inserting dummy metal fill into semiconductor layouts."
 authors = [
     { name = "Daniel Schultz", email = "dnltz@aesc-silicon.de" }


### PR DESCRIPTION
Two critical packaging fixes so both published artifacts install and run.

PyPI wheel was empty:
- After the Rust implementation was introduced, the built wheel shipped no gdsfill Python package, so `pip install gdsfill` installed nothing runnable. Add a [tool.setuptools.packages.find] section so setuptools discovers and bundles the gdsfill package.
- Make the argparse subcommand required (dest='command', required=True) so invoking gdsfill with no subcommand fails with usage instead of an AttributeError.

crates.io package bundled non-Rust files:
- Add a Cargo include whitelist so cargo package/publish bundles only src/, the example configs, README, and license files -- not the Python gdsfill/ tree, build metadata, or venv directories.