### PR TITLE
src: Introduce density_boundary_layer

### DIFF
--- a/src/density.rs
+++ b/src/density.rs
@@ -36,8 +36,8 @@ pub fn run(gds_file: &Path, ctx: RunContext, debug: bool) -> Result<()> {
 
     let mut needed: HashSet<(i16, i16)> = HashSet::new();
 
-    let (bl_layer, bl_datatype) = pdk.boundary_layer
-        .ok_or_else(|| anyhow!("No boundary layer defined for process '{}'", process))?;
+    let (bl_layer, bl_datatype) = pdk.density_boundary_layer
+        .ok_or_else(|| anyhow!("No density boundary layer defined for process '{}'", process))?;
     needed.insert((bl_layer, bl_datatype));
 
     let density_targets = get_target_layers(&ctx);

--- a/src/fill.rs
+++ b/src/fill.rs
@@ -23,8 +23,8 @@ pub fn run(gds_file: &Path, ctx: RunContext, debug: bool, dryrun: bool) -> Resul
 
     let mut needed: HashSet<(i16, i16)> = HashSet::new();
 
-    let (bl_layer, bl_datatype) = pdk.boundary_layer
-        .ok_or_else(|| anyhow!("No boundary layer defined for process '{}'", process))?;
+    let (bl_layer, bl_datatype) = pdk.fill_boundary_layer
+        .ok_or_else(|| anyhow!("No fill boundary layer defined for process '{}'", process))?;
     needed.insert((bl_layer, bl_datatype));
 
     let fill_targets = get_target_layers(&ctx);

--- a/src/pdk/mod.rs
+++ b/src/pdk/mod.rs
@@ -170,8 +170,12 @@ pub struct PdkConstants {
     pub db_unit_um: f64,
     /// Default tile width in micrometres.
     pub tile_width_um: f64,
-    /// GDS (layer, datatype) that defines the chip boundary (Edge.Seal for IHP).
-    pub boundary_layer: Option<(i16, i16)>,
+    /// GDS (layer, datatype) that bounds where fill shapes may be placed
+    /// (prBoundary, (39,0) for IHP).
+    pub fill_boundary_layer: Option<(i16, i16)>,
+    /// GDS (layer, datatype) whose filled exterior defines the reference area
+    /// for density calculation (Edge.Seal, (39,4) for IHP).
+    pub density_boundary_layer: Option<(i16, i16)>,
     /// Manufacturing grid in database units (e.g. 5 DBU = 5 nm for IHP).
     /// Fill shape sizes and spaces are snapped to multiples of `2 * grid_dbu`
     /// so that `half = size/2` always lands on a grid point.
@@ -271,7 +275,8 @@ fn ihp_sg13g2() -> PdkConstants {
         40.0, 10.0, 800.0));
 
     PdkConstants {
-        layers, db_unit_um: 0.001, tile_width_um: 800.0, boundary_layer: Some((39, 0)),
+        layers, db_unit_um: 0.001, tile_width_um: 800.0,
+        fill_boundary_layer: Some((39, 0)), density_boundary_layer: Some((39, 4)),
         grid_dbu: 5.0,
     }
 }
@@ -317,7 +322,8 @@ fn ihp_sg13cmos5l() -> PdkConstants {
         40.0, 10.0, 800.0));
 
     PdkConstants {
-        layers, db_unit_um: 0.001, tile_width_um: 800.0, boundary_layer: Some((39, 0)),
+        layers, db_unit_um: 0.001, tile_width_um: 800.0,
+        fill_boundary_layer: Some((39, 0)), density_boundary_layer: Some((39, 4)),
         grid_dbu: 5.0,
     }
 }


### PR DESCRIPTION
Rename the existing boundary_layer to fill_boundary_layer and add an additional boundary layer for density calculation.

IHP uses EdgeSeal.Boundary instead of EdgeSeal.drawing to calculate the density. Thus, we need two boundary layers for filling and calculating the density. This also slightly changes the final result.